### PR TITLE
Updated release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-myq2",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "MyQ LiftMaster and Chamberlain plugin for HomeBridge (API 2.0): https://github.com/nfarina/homebridge",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated release version to 1.1.7.  This will let Homebridge installs see the update for the added config.schema.json functionality.