### PR TITLE
Add door sensor battery status

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ MyQ2Platform.prototype.updateDoorStates = function (accessory) {
     .getValue();
 
   accessory.getService(Service.GarageDoorOpener)
-    .setCharacteristic(Characteristic.StatusLowBattery, accessory.context.currentBattery);
+    .setCharacteristic(Characteristic.StatusLowBattery, accessory.context.batteryStatus);
 }
 
 // Method to retrieve door state from the server


### PR DESCRIPTION
First cut at presenting low battery status from the door sensor.

Signed-off-by: Eric Sandeen <sandeen@sandeen.net>
---
Note, this is definitely worth a review, I cargo-culted some of it.  :)

I think updating the battery status is opportunistic/lazy but it's not like state changes frequently, so it might be ok.  I'm not 100% sure when new API calls get made but it seems sufficient to just piggyback on the main calls for door state?  If not maybe that needs some adjustment.